### PR TITLE
Improve email API server and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "nodemailer": "^6.9.11"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,94 @@
+const http = require('http');
+
+let nodemailer;
+try {
+  nodemailer = require('nodemailer');
+} catch (err) {
+  console.error('Nodemailer not installed. Email sending will not work until it is installed.');
+}
+
+const PORT = process.env.PORT || 3001;
+
+const server = http.createServer((req, res) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  };
+
+  if (req.url === '/api/send-email') {
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, corsHeaders);
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405, { ...corsHeaders, 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    let body = '';
+
+    req.on('data', chunk => {
+      body += chunk;
+    });
+
+    req.on('end', async () => {
+      let data;
+      try {
+        data = JSON.parse(body);
+      } catch (err) {
+        res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'Invalid JSON' }));
+        return;
+      }
+
+      const { name, email, message } = data;
+      if (!name || !email || !message) {
+        res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'Missing required fields' }));
+        return;
+      }
+
+      try {
+        if (!nodemailer) {
+          throw new Error('Nodemailer module not available');
+        }
+
+        const transporter = nodemailer.createTransport({
+          host: process.env.SMTP_HOST,
+          port: process.env.SMTP_PORT || 587,
+          secure: false,
+          auth: {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASS,
+          },
+        });
+
+        await transporter.sendMail({
+          from: process.env.SMTP_FROM || process.env.SMTP_USER,
+          to: process.env.SMTP_TO || process.env.SMTP_USER,
+          subject: `Portfolio contact from ${name}`,
+          replyTo: email,
+          text: message,
+        });
+
+        res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+      } catch (err) {
+        console.error('Error sending email', err);
+        res.writeHead(500, { ...corsHeaders, 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'Failed to send email' }));
+      }
+    });
+  } else {
+    res.writeHead(404, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders portfolio heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /Karthik Vanabhojana/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.connect-card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.connect-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,25 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill IntersectionObserver for tests
+class IntersectionObserverMock {
+  constructor(callback, options) {
+    this.callback = callback;
+    this.options = options;
+  }
+
+  observe(target) {
+    this.callback([{ isIntersecting: true, target }]);
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserverMock
+});


### PR DESCRIPTION
## Summary
- handle CORS and preflight requests in `/api/send-email`
- strengthen IntersectionObserver mock for tests
- update app test to use role-based heading query
- remove meeting scheduler and simplify contact form
- beautify "Other Ways to Connect" with reusable contact cards and hover styling
- add footer with contact details

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_688da2632f4c832eac53415b9594481f